### PR TITLE
Enable MPS slicing for memory savings

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -42,3 +42,8 @@ RESULTS_FOLDER=generated_images
 # Note: Running on CPU will be extremely slow.
 # Default: (auto-detects cuda, falls back to cpu)
 PYTORCH_DEVICE=cuda
+
+# Enable memory optimizations when using Apple's MPS backend.
+# Set to 0 or "false" to disable.
+# Default: 1 (enabled)
+ENABLE_MPS_SLICING=1

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ RESULTS_FOLDER="generated_images"
 # --- Job & Resource Management ---
 # Device to run the model on ('cuda', 'cpu'). Defaults to 'cuda' if available.
 PYTORCH_DEVICE="cuda"
+# Enable memory optimizations when using Apple's MPS backend (requires PYTORCH_DEVICE="mps").
+ENABLE_MPS_SLICING=1
 # How long to keep job results in memory and on disk (in seconds). Default is 600 (10 minutes).
 JOB_RESULT_TTL=600
 # How often the cleanup worker runs (in seconds). Default is 300 (5 minutes).

--- a/app.py
+++ b/app.py
@@ -97,6 +97,9 @@ try:
     # Use environment variable for device, with auto-detection as fallback
     _default_device = "cuda" if torch.cuda.is_available() else "cpu"
     DEVICE = os.getenv("PYTORCH_DEVICE", _default_device)
+    ENABLE_MPS_SLICING = (
+        os.getenv("ENABLE_MPS_SLICING", "1").lower() not in ["0", "false", "no"]
+    )
     TORCH_DTYPE = (
         torch.bfloat16 if DEVICE == "cuda" else torch.float32
     )  # bfloat16 not supported on CPU for all ops
@@ -123,6 +126,10 @@ try:
         pipe.enable_model_cpu_offload()
     else:
         pipe.to(DEVICE)
+
+    if DEVICE == "mps" and ENABLE_MPS_SLICING:
+        pipe.enable_attention_slicing()
+        pipe.enable_vae_slicing()
 
     logger.info(f"Model initialized successfully on device '{DEVICE}'.")
 


### PR DESCRIPTION
## Summary
- enable attention and VAE slicing when running on Apple's MPS backend
- allow controlling this via new `ENABLE_MPS_SLICING` environment variable
- document the option in `.env_template` and `README`

## Testing
- `python3 -m py_compile app.py`
- `pip install -q -r requirements.txt` *(failed: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_6865a3fa8dd48326a4bba2401e4173a9